### PR TITLE
Docker development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.4.1
+
+RUN apt-get update -qq && \
+    apt-get install -y build-essential libpq-dev nodejs && \
+    mkdir /loud-speaker
+
+WORKDIR /loud-speaker
+
+COPY Gemfile Gemfile.lock /loud-speaker/
+
+RUN bundle install
+
+COPY . /loud-speaker

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.4.1'
 gem 'rails', '~> 5.2.0'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
+gem 'activerecord-postgis-adapter', '~> 5.2.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/config/database.yml
+++ b/config/database.yml
@@ -42,6 +42,8 @@ development:
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
   #port: 5432
+  
+  url: <%= ENV['POSTGRES_URL'] %>
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public

--- a/config/environments/psql-development.env
+++ b/config/environments/psql-development.env
@@ -1,0 +1,4 @@
+POSTGRES_URL=postgis://loud-speaker:loud-speaker@psql:5432/loud-speaker_development
+POSTGRES_DB=loud-speaker_development
+POSTGRES_USER=loud-speaker
+POSTGRES_PASSWORD=loud-speaker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  psql:
+    image: mdillon/postgis:10-alpine
+    restart: on-failure
+    env_file:
+      - ./config/environments/psql-development.env
+    ports:
+      - 5432
+
+  rails:
+    build: .
+    restart: on-failure
+    entrypoint: rails
+    command: server
+    env_file:
+      - ./config/environments/psql-development.env
+    links:
+      - psql
+    ports:
+      - 33000:3000


### PR DESCRIPTION
add a docker-compose file, and a local Dockerfile, for easy development via containers!

Ideally, this doesn't break "native" local development, but that mostly depends on how `./config/database.yml` resolves `url: <%= ENV['POSTGRES_URL'] %>` - Ie: if an empty string for "url" means "don't set URL", then we should be fine. If suddenly, local development cant find the database, then we need to write something like:

<%= ENV['POSTGRES_URL'] ? "url: ${ENV['POSTGRES_URL']}" : "" %>

(ie: if there is a POSTGRES_URL defined, add the `url: ...` key, otherwise dont print anything at all)

development with docker looks like this currently:
Run migration:
`docker-compose run rails db:migrate RAILS_ENV=development`

Run the server:
`docker-compose up rails`

Restart to rebuild changes:
`docker-compose down; docker-compose build rails; docker-compose up rails`

Obviously, could be nicer (auto-reload, don't rebuild-the-world-on-changes, etc etc) but this lets me develop from anywhere (ie: windows without rails / psql) and not pollute my systems 💃 